### PR TITLE
[Feature] 회원 - 로그인

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
+    implementation 'org.springframework.security:spring-security-crypto'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/be/src/main/java/org/kernel360/tang/auth/AuthController.java
+++ b/be/src/main/java/org/kernel360/tang/auth/AuthController.java
@@ -22,14 +22,10 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody LoginRequest request, HttpSession session) {
-        try {
-            Member member = authService.login(request);
-            session.setAttribute("memberId", member.getMemberId());
+        Member member = authService.login(request);
+        session.setAttribute("memberId", member.getMemberId());
 
-            LoginResponse loginResponse = new LoginResponse(member.getUsername());
-            return ResponseEntity.ok(loginResponse);
-        } catch (AppException e) {
-            return new ResponseEntity<>(AppErrorResponse.from(e.getCode()), HttpStatus.UNAUTHORIZED);
-        }
+        LoginResponse loginResponse = new LoginResponse(member.getUsername());
+        return ResponseEntity.ok(loginResponse);
     }
 }

--- a/be/src/main/java/org/kernel360/tang/auth/AuthController.java
+++ b/be/src/main/java/org/kernel360/tang/auth/AuthController.java
@@ -25,7 +25,6 @@ public class AuthController {
         try {
             Member member = authService.login(request);
             session.setAttribute("memberId", member.getMemberId());
-            session.setAttribute("username", member.getUsername());
 
             LoginResponse loginResponse = new LoginResponse(member.getUsername());
             return ResponseEntity.ok(loginResponse);

--- a/be/src/main/java/org/kernel360/tang/auth/AuthController.java
+++ b/be/src/main/java/org/kernel360/tang/auth/AuthController.java
@@ -1,11 +1,11 @@
 package org.kernel360.tang.auth;
 
 import jakarta.servlet.http.HttpSession;
-import java.util.HashMap;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.kernel360.tang.auth.dto.LoginRequest;
 import org.kernel360.tang.auth.dto.LoginResponse;
+import org.kernel360.tang.common.AppErrorResponse;
+import org.kernel360.tang.common.AppException;
 import org.kernel360.tang.member.Member;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,10 +28,8 @@ public class AuthController {
 
             LoginResponse loginResponse = new LoginResponse(member.getUsername());
             return ResponseEntity.ok(loginResponse);
-        } catch (RuntimeException e) {
-            Map<String, String> errorResponse = new HashMap<>();
-            errorResponse.put("message", e.getMessage());
-            return new ResponseEntity<>(errorResponse, HttpStatus.UNAUTHORIZED);
+        } catch (AppException e) {
+            return new ResponseEntity<>(AppErrorResponse.from(e.getCode()), HttpStatus.UNAUTHORIZED);
         }
     }
 }

--- a/be/src/main/java/org/kernel360/tang/auth/AuthController.java
+++ b/be/src/main/java/org/kernel360/tang/auth/AuthController.java
@@ -1,0 +1,38 @@
+package org.kernel360.tang.auth;
+
+import jakarta.servlet.http.HttpSession;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.kernel360.tang.auth.dto.LoginRequest;
+import org.kernel360.tang.auth.dto.LoginResponse;
+import org.kernel360.tang.member.Member;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+@RestController
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody LoginRequest request, HttpSession session) {
+        try {
+            Member member = authService.login(request);
+            session.setAttribute("memberId", member.getMemberId());
+            session.setAttribute("username", member.getUsername());
+
+            LoginResponse loginResponse = new LoginResponse(member.getUsername());
+            return ResponseEntity.ok(loginResponse);
+        } catch (RuntimeException e) {
+            Map<String, String> errorResponse = new HashMap<>();
+            errorResponse.put("message", e.getMessage());
+            return new ResponseEntity<>(errorResponse, HttpStatus.UNAUTHORIZED);
+        }
+    }
+}

--- a/be/src/main/java/org/kernel360/tang/auth/AuthService.java
+++ b/be/src/main/java/org/kernel360/tang/auth/AuthService.java
@@ -2,6 +2,8 @@ package org.kernel360.tang.auth;
 
 import lombok.RequiredArgsConstructor;
 import org.kernel360.tang.auth.dto.LoginRequest;
+import org.kernel360.tang.common.AppException;
+import org.kernel360.tang.common.AuthExceptionCode;
 import org.kernel360.tang.member.Member;
 import org.kernel360.tang.member.MemberMapper;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -16,7 +18,7 @@ public class AuthService {
     public Member login(LoginRequest request) {
         Member member = memberMapper.selectMemberByUsername(request.getUsername());
         if (member == null || !passwordEncoder.matches(request.getPassword(), member.getPassword())) {
-            throw new RuntimeException("로그인 정보가 올바르지 않습니다.");
+            throw new AppException(AuthExceptionCode.INVALID_LOGIN);
         }
         return member;
     }

--- a/be/src/main/java/org/kernel360/tang/auth/AuthService.java
+++ b/be/src/main/java/org/kernel360/tang/auth/AuthService.java
@@ -1,0 +1,22 @@
+package org.kernel360.tang.auth;
+
+import lombok.AllArgsConstructor;
+import org.kernel360.tang.auth.dto.LoginRequest;
+import org.kernel360.tang.member.Member;
+import org.kernel360.tang.member.MemberMapper;
+import org.springframework.stereotype.Service;
+
+@AllArgsConstructor
+@Service
+public class AuthService {
+    private final MemberMapper memberMapper;
+
+    public Member login(LoginRequest request) {
+        Member member = memberMapper.selectMemberByUsername(request.getUsername());
+        // TODO: 비밀번호 검증 기능 추가 필요
+        if (member == null) {
+            throw new RuntimeException("로그인 정보가 올바르지 않습니다.");
+        }
+        return member;
+    }
+}

--- a/be/src/main/java/org/kernel360/tang/auth/AuthService.java
+++ b/be/src/main/java/org/kernel360/tang/auth/AuthService.java
@@ -1,13 +1,13 @@
 package org.kernel360.tang.auth;
 
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.kernel360.tang.auth.dto.LoginRequest;
 import org.kernel360.tang.member.Member;
 import org.kernel360.tang.member.MemberMapper;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-@AllArgsConstructor
+@RequiredArgsConstructor
 @Service
 public class AuthService {
     private final MemberMapper memberMapper;

--- a/be/src/main/java/org/kernel360/tang/auth/AuthService.java
+++ b/be/src/main/java/org/kernel360/tang/auth/AuthService.java
@@ -4,17 +4,18 @@ import lombok.AllArgsConstructor;
 import org.kernel360.tang.auth.dto.LoginRequest;
 import org.kernel360.tang.member.Member;
 import org.kernel360.tang.member.MemberMapper;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @AllArgsConstructor
 @Service
 public class AuthService {
     private final MemberMapper memberMapper;
+    private final PasswordEncoder passwordEncoder;
 
     public Member login(LoginRequest request) {
         Member member = memberMapper.selectMemberByUsername(request.getUsername());
-        // TODO: 비밀번호 검증 기능 추가 필요
-        if (member == null) {
+        if (member == null || !passwordEncoder.matches(request.getPassword(), member.getPassword())) {
             throw new RuntimeException("로그인 정보가 올바르지 않습니다.");
         }
         return member;

--- a/be/src/main/java/org/kernel360/tang/auth/dto/LoginRequest.java
+++ b/be/src/main/java/org/kernel360/tang/auth/dto/LoginRequest.java
@@ -1,12 +1,12 @@
 package org.kernel360.tang.auth.dto;
 
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class LoginRequest {
-    private String username;
-    private String password;
+    private final String username;
+    private final String password;
 }

--- a/be/src/main/java/org/kernel360/tang/auth/dto/LoginRequest.java
+++ b/be/src/main/java/org/kernel360/tang/auth/dto/LoginRequest.java
@@ -1,0 +1,12 @@
+package org.kernel360.tang.auth.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginRequest {
+    private String username;
+    private String password;
+}

--- a/be/src/main/java/org/kernel360/tang/auth/dto/LoginResponse.java
+++ b/be/src/main/java/org/kernel360/tang/auth/dto/LoginResponse.java
@@ -1,0 +1,10 @@
+package org.kernel360.tang.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponse {
+    private String username;
+}

--- a/be/src/main/java/org/kernel360/tang/auth/dto/LoginResponse.java
+++ b/be/src/main/java/org/kernel360/tang/auth/dto/LoginResponse.java
@@ -1,10 +1,10 @@
 package org.kernel360.tang.auth.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class LoginResponse {
-    private String username;
+    private final String username;
 }

--- a/be/src/main/java/org/kernel360/tang/common/AuthExceptionCode.java
+++ b/be/src/main/java/org/kernel360/tang/common/AuthExceptionCode.java
@@ -1,0 +1,29 @@
+package org.kernel360.tang.common;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum AuthExceptionCode implements ExceptionCode {
+    INVALID_LOGIN("INVALID_LOGIN", "로그인 정보가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
+    ;
+
+    public static final String PREFIX = "AUTH";
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatusCode;
+    private final LoggingLevel loggingLevel;
+
+    @Override
+    public String getPrefix() {
+        return PREFIX;
+    }
+
+    AuthExceptionCode(String code, String message, HttpStatus httpStatusCode) {
+        this.code = code;
+        this.message = message;
+        this.httpStatusCode = httpStatusCode;
+        this.loggingLevel = LoggingLevel.INTERNAL_ERROR;
+    }
+}

--- a/be/src/main/java/org/kernel360/tang/config/SecurityConfig.java
+++ b/be/src/main/java/org/kernel360/tang/config/SecurityConfig.java
@@ -1,0 +1,23 @@
+package org.kernel360.tang.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        String defaultPasswordEncoderId = "bcrypt";
+        Map<String, PasswordEncoder> encoders = new HashMap<>();
+        encoders.put(defaultPasswordEncoderId, new BCryptPasswordEncoder());
+        encoders.put("noop", NoOpPasswordEncoder.getInstance());
+        return new DelegatingPasswordEncoder(defaultPasswordEncoderId, encoders);
+    }
+}

--- a/be/src/main/java/org/kernel360/tang/member/Member.java
+++ b/be/src/main/java/org/kernel360/tang/member/Member.java
@@ -1,0 +1,12 @@
+package org.kernel360.tang.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Member {
+    private Long memberId;
+    private String username;
+    private String password;
+}

--- a/be/src/main/java/org/kernel360/tang/member/Member.java
+++ b/be/src/main/java/org/kernel360/tang/member/Member.java
@@ -1,12 +1,12 @@
 package org.kernel360.tang.member;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class Member {
-    private Long memberId;
-    private String username;
-    private String password;
+    private final Long memberId;
+    private final String username;
+    private final String password;
 }

--- a/be/src/main/java/org/kernel360/tang/member/MemberMapper.java
+++ b/be/src/main/java/org/kernel360/tang/member/MemberMapper.java
@@ -1,0 +1,8 @@
+package org.kernel360.tang.member;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface MemberMapper {
+    Member selectMemberByUsername(String username);
+}

--- a/be/src/main/resources/mapper/MemberMapper.xml
+++ b/be/src/main/resources/mapper/MemberMapper.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "//mybatis.org/DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+<mapper namespace="org.kernel360.tang.member.MemberMapper">
+
+  <select id="selectMemberByUsername" resultType="org.kernel360.tang.member.Member">
+    SELECT member_id, username, password
+    FROM member
+    WHERE username = #{username}
+  </select>
+
+</mapper>


### PR DESCRIPTION
## 관련 이슈
- #6 

## PR
> 사용자가 아이디/비밀번호 조합으로 서비스에 로그인할 수 있습니다.

## 📝 주요 리뷰 사항
- 현재 `auth`와 `member` 도메인을 분리하여 사용하고 있습니다. 이러한 구조가 **책임 분리**에 적절한지 의견을 부탁드립니다.
- `SecurityConfig`에서 **PasswordEncoder Bean**을 설정하는 로직에 대한 검토를 요청드립니다.
- 현재 로그인 시 **회원 존재 여부** 및 **비밀번호 검증 실패** 시  RuntimeException을 throw하고 있으며, AuthController의 try-catch 블록에서 임시로 처리하고 있습니다. 이 예외를 공통 에러 처리(`AppExceptionAdvice`)로 통합하여 관리하는 것이 더 적절할지에 대한 의견을 구합니다.
  ```Java
  public ResponseEntity<?> login(@RequestBody LoginRequest request, HttpSession session) {
      try {
          Member member = authService.login(request);
          session.setAttribute("memberId", member.getMemberId());
          session.setAttribute("username", member.getUsername());

          LoginResponse loginResponse = new LoginResponse(member.getUsername());
          return ResponseEntity.ok(loginResponse);
      } catch (RuntimeException e) {
          Map<String, String> errorResponse = new HashMap<>();
          errorResponse.put("message", e.getMessage());
          return new ResponseEntity<>(errorResponse, HttpStatus.UNAUTHORIZED);
      }
  }
  ```

## 🔥 주요 변경 사항
- [x] 사용자는 가입한 아이디/비밀번호 조합으로 서비스에 로그인할 수 있습니다.
- [x] 사용자 인증은 Session을 사용합니다.

## 📚 참고 자료
