### PR TITLE
[FIX] AppException의 생성자 public으로 수정

### DIFF
--- a/be/src/main/java/org/kernel360/tang/common/AppException.java
+++ b/be/src/main/java/org/kernel360/tang/common/AppException.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 public class AppException extends RuntimeException {
     private final ExceptionCode code;
 
-    AppException(ExceptionCode code) {
+    public AppException(ExceptionCode code) {
         super(code.getMessage());
         this.code = code;
     }


### PR DESCRIPTION
## 관련 이슈
- #18 

## PR
> AppException의 생성자 public으로 수정하여 버그 해결합니다.

## 📝 주요 리뷰 사항

## 🔥 주요 변경 사항
- [x] AppException의 생성자 public으로 수정

## 📚 참고 자료

---

this closes #18 