### PR TITLE
[Feature] 예약한 좌석 목록 조회 API 추가

### DIFF
--- a/be/src/main/java/org/kernel360/tang/seat/SeatController.java
+++ b/be/src/main/java/org/kernel360/tang/seat/SeatController.java
@@ -1,0 +1,36 @@
+package org.kernel360.tang.seat;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/seats")
+@RequiredArgsConstructor
+public class SeatController {
+
+    private final SeatService seatService;
+
+    @GetMapping
+    public ResponseEntity<List<SeatReservationResponse>> getUserReservations(
+            @ModelAttribute UserReservationGetRequest request
+    ) {
+        List<SeatReservationDto> userReservations = seatService.getUserReservations(
+                1,  // todo: 인가 방식 정해진 후 변경
+                request.status(),
+                request.startDate(),
+                request.endDate()
+        );
+
+        List<SeatReservationResponse> response = userReservations.stream().map(SeatReservationResponse::from)
+                .toList();
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(response);
+    }
+}

--- a/be/src/main/java/org/kernel360/tang/seat/SeatExceptionCode.java
+++ b/be/src/main/java/org/kernel360/tang/seat/SeatExceptionCode.java
@@ -1,0 +1,32 @@
+package org.kernel360.tang.seat;
+
+import lombok.Getter;
+import org.kernel360.tang.common.ExceptionCode;
+import org.kernel360.tang.common.LoggingLevel;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum SeatExceptionCode implements ExceptionCode {
+
+    INVALID_RESERVATION_TIME_RANGE("INVALID_RESERVATION_TIME_RANGE", "3개월 이상의 기간을 조회할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    ;
+
+    public static final String PREFIX = "SEAT";
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatusCode;
+    private final LoggingLevel loggingLevel;
+
+    @Override
+    public String getPrefix() {
+        return PREFIX;
+    }
+
+    SeatExceptionCode(String code, String message, HttpStatus httpStatusCode) {
+        this.code = code;
+        this.message = message;
+        this.httpStatusCode = httpStatusCode;
+        this.loggingLevel = LoggingLevel.APP_ERROR;
+    }
+}

--- a/be/src/main/java/org/kernel360/tang/seat/SeatMapper.java
+++ b/be/src/main/java/org/kernel360/tang/seat/SeatMapper.java
@@ -1,0 +1,16 @@
+package org.kernel360.tang.seat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface SeatMapper {
+
+    List<SeatReservationDto> getUserReservations(
+            Integer memberId,
+            Integer status,
+            LocalDateTime startDate,
+            LocalDateTime endDate
+    );
+}

--- a/be/src/main/java/org/kernel360/tang/seat/SeatReservationDto.java
+++ b/be/src/main/java/org/kernel360/tang/seat/SeatReservationDto.java
@@ -1,0 +1,15 @@
+package org.kernel360.tang.seat;
+
+import java.time.LocalDateTime;
+
+public record SeatReservationDto(
+        int reservationId,
+        int memberId,
+        int seatId,
+        LocalDateTime startAt,
+        LocalDateTime endAt,
+        int statusCode,
+        LocalDateTime reservedAt,
+        LocalDateTime canceledAt
+) {
+}

--- a/be/src/main/java/org/kernel360/tang/seat/SeatReservationResponse.java
+++ b/be/src/main/java/org/kernel360/tang/seat/SeatReservationResponse.java
@@ -1,0 +1,24 @@
+package org.kernel360.tang.seat;
+
+import java.time.LocalDateTime;
+
+public record SeatReservationResponse(
+        int reservationId,
+        int seatId,
+        int memberId,
+        SeatReservationStatus status,
+        LocalDateTime reservedAt,
+        LocalDateTime canceledAt
+) {
+
+    public static SeatReservationResponse from(SeatReservationDto seatReservationDto) {
+        return new SeatReservationResponse(
+                seatReservationDto.reservationId(),
+                seatReservationDto.seatId(),
+                seatReservationDto.memberId(),
+                SeatReservationStatus.fromCode(seatReservationDto.statusCode()),
+                seatReservationDto.reservedAt(),
+                seatReservationDto.canceledAt()
+        );
+    }
+}

--- a/be/src/main/java/org/kernel360/tang/seat/SeatReservationStatus.java
+++ b/be/src/main/java/org/kernel360/tang/seat/SeatReservationStatus.java
@@ -1,0 +1,27 @@
+package org.kernel360.tang.seat;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.kernel360.tang.common.AppException;
+import org.kernel360.tang.common.CommonExceptionCode;
+
+@RequiredArgsConstructor
+@Getter
+public enum SeatReservationStatus {
+
+    PENDING(0),
+    CONFIRMED(1),
+    CANCELED(2)
+    ;
+
+    private final int code;
+
+    public static SeatReservationStatus fromCode(int code) {
+        return switch (code) {
+            case 0 -> PENDING;
+            case 1 -> CONFIRMED;
+            case 2 -> CANCELED;
+            default -> throw new AppException(CommonExceptionCode.INTERNAL_SERVER_ERROR);
+        };
+    }
+}

--- a/be/src/main/java/org/kernel360/tang/seat/SeatService.java
+++ b/be/src/main/java/org/kernel360/tang/seat/SeatService.java
@@ -1,0 +1,29 @@
+package org.kernel360.tang.seat;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.kernel360.tang.common.AppException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SeatService {
+
+    public static final int MAX_RESERVATION_SELECT_TIME_DAY = 90;
+    private final SeatMapper seatMapper;
+
+    List<SeatReservationDto> getUserReservations(
+            Integer memberId,
+            SeatReservationStatus status,
+            LocalDateTime startDate,
+            LocalDateTime endDate
+    ) {
+        if (Duration.between(startDate, endDate).toDays() > MAX_RESERVATION_SELECT_TIME_DAY) {
+            throw new AppException(SeatExceptionCode.INVALID_RESERVATION_TIME_RANGE);
+        }
+
+        return seatMapper.getUserReservations(memberId, status.getCode(), startDate, endDate);
+    }
+}

--- a/be/src/main/java/org/kernel360/tang/seat/UserReservationGetRequest.java
+++ b/be/src/main/java/org/kernel360/tang/seat/UserReservationGetRequest.java
@@ -1,0 +1,11 @@
+package org.kernel360.tang.seat;
+
+import java.time.LocalDateTime;
+
+public record UserReservationGetRequest(
+
+        SeatReservationStatus status,
+        LocalDateTime startDate,
+        LocalDateTime endDate
+) {
+}

--- a/be/src/main/resources/mapper/SeatMapper.xml
+++ b/be/src/main/resources/mapper/SeatMapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.kernel360.tang.seat.SeatMapper">
+
+	<select id="getUserReservations" resultType="org.kernel360.tang.seat.SeatReservationDto">
+		SELECT
+			sr.resv_id AS reservationId,
+			sr.member_id AS memberId,
+			st.seat_id AS seatId,
+			st.start_dt AS startAt,
+			st.end_dt AS endAt,
+			sr.status AS statusCode,
+			sr.reserved_at AS reservedAt,
+			sr.canceled_at AS canceledAt
+		FROM seat_resv sr INNER JOIN seat_time st ON sr.time_id = st.time_id
+		WHERE sr.member_id = #{memberId}
+			<if test="status != null">
+				AND sr.status = #{status}
+			</if>
+			AND st.start_dt >= #{startDate}
+		  AND st.end_dt &lt;= #{endDate}
+	</select>
+
+</mapper>


### PR DESCRIPTION
## 관련 이슈
- #13 

## PR
> 예약한 좌석 목록 조회

## 📝 주요 리뷰 사항

## 🔥 주요 변경 사항
- [x] 사용자가 자신이 예약한 좌석 목록을 조회할 수 있습니다.
- [x] 취소한 예약 목록도 조회할 수 있어야 합니다.
- [x] "예약 완료" 또는 "예약 취소" 를 조건으로 조회할 수 있습니다.
- [x] 날짜 구간을 지정하여 예약 목록을 조회할 수 있습니다.
- [x] 조회 조건의 날짜 길이는 최대 3개월까지 가능합니다.

## 📚 참고 자료

---

this closes #13 