### PR TITLE
feat: 여러 좌석의 시간내 모든 seatTime 예약

### DIFF
--- a/be/src/main/java/org/kernel360/tang/seatReservation/SeatReservationController.java
+++ b/be/src/main/java/org/kernel360/tang/seatReservation/SeatReservationController.java
@@ -2,12 +2,9 @@ package org.kernel360.tang.seatReservation;
 
 import lombok.RequiredArgsConstructor;
 import org.kernel360.tang.common.Constants;
+import org.kernel360.tang.seatReservation.dto.MultipleSeatRangeReservationRequest;
 import org.kernel360.tang.seatReservation.dto.SeatReservationRequest;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestAttribute;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/reserve")
@@ -21,5 +18,13 @@ public class SeatReservationController {
             @RequestAttribute(Constants.SESSION_MEMBER_ID) Integer memberId
     ) {
         seatReservationService.reserveSeats(memberId, request);
+    }
+
+    @PostMapping("/multi-range")
+    public void reserveMultiSeatRange(
+            @RequestBody MultipleSeatRangeReservationRequest request,
+            @RequestAttribute(Constants.SESSION_MEMBER_ID) Integer memberId
+    ) {
+        seatReservationService.reserveMultiSeatRange(memberId, request);
     }
 }

--- a/be/src/main/java/org/kernel360/tang/seatReservation/dto/MultipleSeatRangeReservationRequest.java
+++ b/be/src/main/java/org/kernel360/tang/seatReservation/dto/MultipleSeatRangeReservationRequest.java
@@ -1,0 +1,15 @@
+package org.kernel360.tang.seatReservation.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MultipleSeatRangeReservationRequest(
+        List<SeatTimeRangeItem> items
+) {
+    public record SeatTimeRangeItem(
+            Integer seatId,
+            LocalDateTime startDt,
+            LocalDateTime endDt
+    ) {
+    }
+}

--- a/be/src/main/java/org/kernel360/tang/seatReservation/vo/ReserveOneSeatVo.java
+++ b/be/src/main/java/org/kernel360/tang/seatReservation/vo/ReserveOneSeatVo.java
@@ -21,4 +21,13 @@ public class ReserveOneSeatVo {
                 reservedAt
         );
     }
+
+    public static ReserveOneSeatVo from(Integer memberId, Integer timeId, LocalDateTime reservedAt) {
+        return new ReserveOneSeatVo(
+                timeId,
+                memberId,
+                SeatReservationStatus.RESERVED,
+                reservedAt
+        );
+    }
 }

--- a/be/src/main/java/org/kernel360/tang/seatTime/SeatTimeMapper.java
+++ b/be/src/main/java/org/kernel360/tang/seatTime/SeatTimeMapper.java
@@ -3,7 +3,12 @@ package org.kernel360.tang.seatTime;
 import org.apache.ibatis.annotations.Mapper;
 import org.kernel360.tang.seatTime.vo.SeatTimeVo;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Mapper
 public interface SeatTimeMapper {
     SeatTimeVo findById(Integer timeId);
+
+    List<SeatTimeVo> findBySeatIdAndDateBetween(Integer seatId, LocalDateTime startDt, LocalDateTime endDt);
 }

--- a/be/src/main/resources/mapper/mapper-seatTime.xml
+++ b/be/src/main/resources/mapper/mapper-seatTime.xml
@@ -8,4 +8,11 @@
         FROM seat_time
         WHERE time_id = #{id}
     </select>
+    <select id="findBySeatIdAndDateBetween" resultType="org.kernel360.tang.seatTime.vo.SeatTimeVo">
+        SELECT time_id, seat_id, start_dt, end_dt
+        FROM seat_time
+        WHERE seat_id = #{seatId}
+          AND start_dt >= #{startDt}
+          AND #{endDt} > end_dt
+    </select>
 </mapper>

--- a/be/src/test/resources/database/init.sql
+++ b/be/src/test/resources/database/init.sql
@@ -64,6 +64,10 @@ INSERT INTO seat (name, room_id)
 VALUES ('좌석 4', 1);
 INSERT INTO seat (name, room_id)
 VALUES ('좌석 5', 1);
+INSERT INTO seat (name, room_id)
+VALUES ('좌석 6', 1);
+INSERT INTO seat (name, room_id)
+VALUES ('좌석 7', 1);
 
 INSERT INTO seat_time (seat_id, start_dt, end_dt)
 VALUES (1, '2024-10-01 09:00', '2024-10-01 10:00');
@@ -79,6 +83,21 @@ INSERT INTO seat_time (seat_id, start_dt, end_dt)
 VALUES (1, '2024-10-01 10:00', '2024-10-01 11:00');
 INSERT INTO seat_time (seat_id, start_dt, end_dt)
 VALUES (3, '2024-10-01 10:00', '2024-10-01 11:00');
+
+INSERT INTO seat_time (seat_id, start_dt, end_dt)
+VALUES (6, '2024-10-01 09:00', '2024-10-01 09:30'),
+       (6, '2024-10-01 09:30', '2024-10-01 10:00'),
+       (6, '2024-10-01 10:00', '2024-10-01 10:30'),
+       (6, '2024-10-01 10:30', '2024-10-01 11:00'),
+       (6, '2024-10-01 11:00', '2024-10-01 11:30'),
+       (6, '2024-10-01 11:30', '2024-10-01 12:00');
+INSERT INTO seat_time (seat_id, start_dt, end_dt)
+VALUES (7, '2024-10-01 09:00', '2024-10-01 09:30'),
+       (7, '2024-10-01 09:30', '2024-10-01 10:00'),
+       (7, '2024-10-01 10:00', '2024-10-01 10:30'),
+       (7, '2024-10-01 10:30', '2024-10-01 11:00'),
+       (7, '2024-10-01 11:00', '2024-10-01 11:30'),
+       (7, '2024-10-01 11:30', '2024-10-01 12:00');
 
 INSERT INTO seat_resv (time_id, member_id, status, reserved_at, canceled_at)
 VALUES (1, 1, 1, '2024-09-30 09:00', NULL);


### PR DESCRIPTION
## 관련 이슈
- #12

## PR
> 시간 구간을 모두 이용 가능한 좌석의 시간대를 모두 예약

## 📝 주요 리뷰 사항
- 

## 🔥 주요 변경 사항
- [x] 사용자가 여러 좌석 및 시간을 지정하여 예약할 수 있습니다.
- [x] 예약하려는 좌석 및 시간 중 하나라도 실패할 경우 전체 예약이 실패해야 합니다.
- [] 어떤 좌석-시간 쌍에 대해 여러 예약이 수행되면 안됩니다.
- [ ] (선택) 예약 실패 확률을 줄이기 위해 최종 확인 전에 좌석을 임시로 점유하도록 합니다.

## 📚 참고 자료
